### PR TITLE
Python3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ or::
 
     easy_install roscraco
 
+roscraco aims to be compatible with python2 and python3. If you notice
+any compatibility problems, please let us know.
+
 
 Supported devices
 -----------------

--- a/roscraco/__init__.py
+++ b/roscraco/__init__.py
@@ -13,7 +13,7 @@
 from . import helper
 from . import response
 from . import router
-from exception import RouterNotSupported
+from .exception import RouterNotSupported
 
 
 __title__ = 'roscraco'

--- a/roscraco/helper/converter.py
+++ b/roscraco/helper/converter.py
@@ -18,7 +18,7 @@ def long2ip(ip):
 
 def normalize_mac(mac):
     """Converts any MAC address format to lowercase HEX with no separators."""
-    from validator import is_valid_mac_address
+    from .validator import is_valid_mac_address
     mac = mac.lower()
     if not is_valid_mac_address(mac):
         raise RouterParseError('MAC address %s is invalid!' % mac)

--- a/roscraco/response/__init__.py
+++ b/roscraco/response/__init__.py
@@ -1,7 +1,7 @@
-from info import RouterInfo
-from dmz import DMZSettings
-from stats import TrafficStats
-from wireless import WirelessSettings
-from dhcp import DHCPReservationList, DHCPReservationListItem, \
+from .info import RouterInfo
+from .dmz import DMZSettings
+from .stats import TrafficStats
+from .wireless import WirelessSettings
+from .dhcp import DHCPReservationList, DHCPReservationListItem, \
      DHCPServerSettings
-from clients import ConnectedClientsList, ConnectedClientsListItem
+from .clients import ConnectedClientsList, ConnectedClientsListItem

--- a/roscraco/router/base.py
+++ b/roscraco/router/base.py
@@ -232,7 +232,7 @@ class RouterBase(object):
                     handle.info(),
                     handle.read().decode('utf-8', 'ignore')
                 )
-        except Exception, e:
+        except Exception as e:
             raise RouterFetchError('Failed making request: %s' % repr(e))
 
     def close(self):

--- a/roscraco/router/canyon/__init__.py
+++ b/roscraco/router/canyon/__init__.py
@@ -1,3 +1,3 @@
-from cnwf514 import Canyon_CNWF514
-from cnpwf514n1 import Canyon_CNPWF514N1
-from cnpwf518n3 import Canyon_CNPWF518N3
+from .cnwf514 import Canyon_CNWF514
+from .cnpwf514n1 import Canyon_CNPWF514N1
+from .cnpwf518n3 import Canyon_CNPWF518N3

--- a/roscraco/router/canyon/cnpwf514n1.py
+++ b/roscraco/router/canyon/cnpwf514n1.py
@@ -14,8 +14,7 @@ from roscraco.response import RouterInfo, TrafficStats, DMZSettings, \
 class Canyon_CNPWF514N1(RouterBase):
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
-        kwargs['headers'] = [('Authorization', 'Basic %s' % auth)]
+        kwargs['headers'] = [('Authorization', 'Basic %s' % self._prepare_base64_auth_string())]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 
     def confirm_identity(self):

--- a/roscraco/router/canyon/cnpwf518n3.py
+++ b/roscraco/router/canyon/cnpwf518n3.py
@@ -1,4 +1,4 @@
-from cnpwf514n1 import Canyon_CNPWF514N1
+from .cnpwf514n1 import Canyon_CNPWF514N1
 
 class Canyon_CNPWF518N3(Canyon_CNPWF514N1):
     pass

--- a/roscraco/router/canyon/cnwf514.py
+++ b/roscraco/router/canyon/cnwf514.py
@@ -14,8 +14,7 @@ from roscraco.response import RouterInfo, TrafficStats, DMZSettings, \
 class Canyon_CNWF514(RouterBase):
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
-        kwargs['headers'] = [('Authorization', 'Basic %s' % auth)]
+        kwargs['headers'] = [('Authorization', 'Basic %s' % self._prepare_base64_auth_string())]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 
     def confirm_identity(self):

--- a/roscraco/router/netgear/__init__.py
+++ b/roscraco/router/netgear/__init__.py
@@ -1,1 +1,1 @@
-from wgr614 import Netgear_WGR614v7, Netgear_WGR614v8, Netgear_WGR614v9
+from .wgr614 import Netgear_WGR614v7, Netgear_WGR614v8, Netgear_WGR614v9

--- a/roscraco/router/netgear/wgr614.py
+++ b/roscraco/router/netgear/wgr614.py
@@ -20,8 +20,7 @@ class NetgearWGR614Base(RouterBase):
         self._is_logged_in = False
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
-        kwargs['headers'] = [('Authorization', 'Basic %s' % auth)]
+        kwargs['headers'] = [('Authorization', 'Basic %s' % self._prepare_base64_auth_string())]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 
     def _handle_first_request(self):

--- a/roscraco/router/tenda/__init__.py
+++ b/roscraco/router/tenda/__init__.py
@@ -1,1 +1,1 @@
-from w268r import Tenda_W268R
+from .w268r import Tenda_W268R

--- a/roscraco/router/tenda/w268r.py
+++ b/roscraco/router/tenda/w268r.py
@@ -13,9 +13,8 @@ from roscraco.response import RouterInfo, TrafficStats, DMZSettings, \
 class Tenda_W268R(RouterBase):
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
         kwargs['headers'] = [
-            ('Authorization', 'Basic %s' % auth),
+            ('Authorization', 'Basic %s' % self._prepare_base64_auth_string()),
         ]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 

--- a/roscraco/router/tomato/__init__.py
+++ b/roscraco/router/tomato/__init__.py
@@ -1,1 +1,1 @@
-from v1_23 import Tomato_1_23
+from .v1_23 import Tomato_1_23

--- a/roscraco/router/tomato/v1_23.py
+++ b/roscraco/router/tomato/v1_23.py
@@ -16,8 +16,7 @@ from roscraco.response import RouterInfo, TrafficStats, DMZSettings, \
 class Tomato_1_23(RouterBase):
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
-        kwargs['headers'] = [('Authorization', 'Basic %s' % auth)]
+        kwargs['headers'] = [('Authorization', 'Basic %s' % self._prepare_base64_auth_string())]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 
     def confirm_identity(self):

--- a/roscraco/router/tplink/__init__.py
+++ b/roscraco/router/tplink/__init__.py
@@ -1,9 +1,9 @@
-from wr340g import Tplink_WR340G, Tplink_WR340Gv4
+from .wr340g import Tplink_WR340G, Tplink_WR340Gv4
 
-from wr720n import Tplink_WR720N
+from .wr720n import Tplink_WR720N
 
-from wr740n import Tplink_WR740N
-from wr741n import Tplink_WR741N
+from .wr740n import Tplink_WR740N
+from .wr741n import Tplink_WR741N
 
-from wr940n import Tplink_WR940N
-from wr941n import Tplink_WR941N
+from .wr940n import Tplink_WR940N
+from .wr941n import Tplink_WR941N

--- a/roscraco/router/tplink/base.py
+++ b/roscraco/router/tplink/base.py
@@ -22,10 +22,9 @@ class TplinkBase(RouterBase):
         # A bug report was submitted to TpLink, but still no progress.
         # Even if they fix it, thousands of routers out there would still
         # run the old firmware and break.
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
         kwargs['headers'] = [
             ('Accept-Encoding', 'gzip,deflate'),
-            ('Authorization', 'Basic %s' % auth),
+            ('Authorization', 'Basic %s' % self._prepare_base64_auth_string()),
         ]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 

--- a/roscraco/router/tplink/base.py
+++ b/roscraco/router/tplink/base.py
@@ -147,7 +147,7 @@ def _extract_js_array_data(contents, array_name):
         result = tuple([v.decode('utf-8', 'ignore')
                         if isinstance(v, bytes) else v for v in result])
         return result
-    except Exception, e:
+    except Exception as e:
         raise RouterParseError('Failed at evaluating array %s: %s' % (array_name, repr(e)))
 
 
@@ -160,7 +160,7 @@ def _parse_pppoe_online_time(data_array):
             return None
 
         return _parse_uptime_to_seconds(uptime_string)
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError('Cannot access the array index: %s' % repr(e))
 
 
@@ -182,7 +182,7 @@ def _parse_uptime_to_seconds(string):
 def _parse_uptime(data_array):
     try:
         return int(data_array[4])
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError('Cannot access the array index: %s' % repr(e))
 
 
@@ -193,14 +193,14 @@ def _parse_router_info(data_array):
         obj.set_firmware_version(data_array[5])
 
         return obj
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError('Cannot access the array index: %s' % repr(e))
 
 
 def _parse_mac_address(data_array):
     try:
         return converter.normalize_mac(data_array[1])
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError('Cannot access the array index: %s' % repr(e))
 
 
@@ -208,7 +208,7 @@ def _parse_dns_servers(data_array):
     try:
         dns_ips = data_array[11].split(' , ')
         return [ip.strip(' ') for ip in dns_ips if validator.is_valid_ip_address(ip)]
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError('Cannot access the array index: %s' % repr(e))
 
 
@@ -232,7 +232,7 @@ def _parse_lease_time(string):
 
     try:
         parts = map(int, parts)
-    except ValueError, e:
+    except ValueError as e:
         raise RouterParseError('Found non-numeric part in lease time %s: %s' % (string, repr(e)))
 
     hours, minutes, seconds = parts
@@ -256,7 +256,7 @@ def _parse_dmz_settings(contents):
         obj.set_ip(result[1])
 
         return obj
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError(repr(e))
 
 
@@ -315,7 +315,7 @@ def _parse_dhcp_settings(html):
         settings.set_enabled_status(int(array[0]) == 1)
         settings.set_ip_start(array[1])
         settings.set_ip_end(array[2])
-    except IndexError, e:
+    except IndexError as e:
         raise RouterParseError(repr(e))
 
     settings.ensure_valid()

--- a/roscraco/router/tplink/wr340g.py
+++ b/roscraco/router/tplink/wr340g.py
@@ -1,10 +1,10 @@
 import urllib
 
 from roscraco.response import WirelessSettings
-from base import TplinkBase, _extract_js_array_data
+from .base import TplinkBase, _extract_js_array_data
 from roscraco.exception import RouterFetchError
 
-from wr740n import Tplink_WR740N
+from .wr740n import Tplink_WR740N
 
 
 # Tp-Link WR340G v4 devices seem to be managed just like WR740N devices.

--- a/roscraco/router/tplink/wr340g.py
+++ b/roscraco/router/tplink/wr340g.py
@@ -27,7 +27,7 @@ class Tplink_WR340G(TplinkBase):
             # Settings are successfully pushed and the router will
             # start the rebooting process if we find this string.
             return 'Please wait a moment' in contents
-        except RouterFetchError, e:
+        except RouterFetchError as e:
             # It sometimes updates the settings and
             # starts rebooting without sending a response correctly.
             # Try to detect that timeout and consider it a success too,

--- a/roscraco/router/tplink/wr720n.py
+++ b/roscraco/router/tplink/wr720n.py
@@ -1,4 +1,4 @@
-from wr740n import Tplink_WR740N
+from .wr740n import Tplink_WR740N
 
 
 class Tplink_WR720N(Tplink_WR740N):

--- a/roscraco/router/tplink/wr740n.py
+++ b/roscraco/router/tplink/wr740n.py
@@ -1,7 +1,7 @@
 import urllib
 
 from roscraco.response import WirelessSettings
-from base import TplinkBase, _extract_js_array_data
+from .base import TplinkBase, _extract_js_array_data
 
 
 class Tplink_WR740N(TplinkBase):

--- a/roscraco/router/tplink/wr741n.py
+++ b/roscraco/router/tplink/wr741n.py
@@ -1,4 +1,4 @@
-from wr740n import Tplink_WR740N
+from .wr740n import Tplink_WR740N
 
 
 class Tplink_WR741N(Tplink_WR740N):

--- a/roscraco/router/tplink/wr940n.py
+++ b/roscraco/router/tplink/wr940n.py
@@ -1,4 +1,4 @@
-from wr740n import Tplink_WR740N
+from .wr740n import Tplink_WR740N
 
 
 class Tplink_WR940N(Tplink_WR740N):

--- a/roscraco/router/tplink/wr941n.py
+++ b/roscraco/router/tplink/wr941n.py
@@ -1,4 +1,4 @@
-from wr740n import Tplink_WR740N
+from .wr740n import Tplink_WR740N
 
 
 class Tplink_WR941N(Tplink_WR740N):

--- a/roscraco/router/zyxel/__init__.py
+++ b/roscraco/router/zyxel/__init__.py
@@ -1,2 +1,2 @@
-from p320w import Zyxel_P320W
-from p330w import Zyxel_P330W
+from .p320w import Zyxel_P320W
+from .p330w import Zyxel_P330W

--- a/roscraco/router/zyxel/p330w.py
+++ b/roscraco/router/zyxel/p330w.py
@@ -15,8 +15,7 @@ from roscraco.response import RouterInfo, TrafficStats, DMZSettings, \
 class Zyxel_P330W(RouterBase):
 
     def _perform_http_request(self, *args, **kwargs):
-        auth = base64.b64encode('%s:%s' % (self.username, self.password))
-        kwargs['headers'] = [('Authorization', 'Basic %s' % auth)]
+        kwargs['headers'] = [('Authorization', 'Basic %s' % self._prepare_base64_auth_string())]
         return RouterBase._perform_http_request(self, *args, **kwargs)
 
     def _wait_for_settings_reload(self, wait_time=32):


### PR DESCRIPTION
I've attempted to make roscraco compatible with python2 and python3 simultaneously. I don't know if there is anything else necessary for this, such as changes to setup.py, as I haven't attempted to use it myself. Also, I only have a TP-LINK WR740N to test with, so there could be other code in the module that still needs to be migrated.

I believe this is a great start though.
